### PR TITLE
Rad/improve 1.0.3 after

### DIFF
--- a/starpy/fastagi.py
+++ b/starpy/fastagi.py
@@ -166,7 +166,7 @@ class FastAGIProtocol(basic.LineOnlyReceiver):
         """(Internal) Check for a failure-code, raise error if == result"""
         # result code may have trailing information...
         try:
-            resultInt, line = result.split(' ', 1)
+            resultInt, line = result.split(b' ', 1)
         except ValueError as err:
             resultInt = result
         if resultInt.strip() == failure:

--- a/starpy/fastagi.py
+++ b/starpy/fastagi.py
@@ -429,7 +429,7 @@ class FastAGIProtocol(basic.LineOnlyReceiver):
         """
         command = '''EXEC "%s"''' % (application)
         if options:
-            if kwargs.pop('comma_delimiter', False) is True:
+            if kwargs.pop('comma_delimiter', True) is True:
                 delimiter = ","
             else:
                 delimiter = "|"


### PR DESCRIPTION
- fix checkFailure with cast to bytes 
- Set comma-separated default value to True since Asterisk 1.6+, more than 20 years.  
